### PR TITLE
[buster] libav-tools dependency to be replaced to ffmpeg

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="php-intl php-curl php-mbstring libav-tools"
+pkg_dependencies="php-intl php-curl php-mbstring libav-tools|ffmpeg"
 
 #=================================================
 # PERSONAL HELPERS


### PR DESCRIPTION
Install fails on buster, gotta update this dependency. This change should do the trick and keep the backward compatibility (`|` is interpreted as an 'or'). I didn't test it tho.