### PR TITLE
End of alltubedownload.net hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ Web interface for Youtube-dl
 
 **Shipped version:** 3.1.0~ynh1
 
-**Demo:** https://alltubedownload.net/
-
 ## Screenshots
 
 ![Screenshot of AllTube](./doc/screenshots/screenshot.png)
@@ -37,7 +35,6 @@ To configure AllTube: edit the file `/var/www/alltube/config/config.yml` via SSH
 
 ## Documentation and resources
 
-* Official app website: <https://alltubedownload.net/>
 * Official admin documentation: <https://github.com/Rudloff/alltube/blob/master/resources/FAQ.md>
 * Upstream app code repository: <https://github.com/Rudloff/alltube>
 * YunoHost documentation for this app: <https://yunohost.org/app_alltube>

--- a/README_fr.md
+++ b/README_fr.md
@@ -19,8 +19,6 @@ Interface Web pour Youtube-dl
 
 **Version incluse :** 3.1.0~ynh1
 
-**Démo :** https://alltubedownload.net/
-
 ## Captures d'écran
 
 ![Capture d'écran de AllTube](./doc/screenshots/screenshot.png)
@@ -37,7 +35,6 @@ Pour configurer AllTube : éditez le fichier `/var/www/alltube/config/config.yml
 
 ## Documentations et ressources
 
-* Site officiel de l'app : <https://alltubedownload.net/>
 * Documentation officielle de l'admin : <https://github.com/Rudloff/alltube/blob/master/resources/FAQ.md>
 * Dépôt de code officiel de l'app : <https://github.com/Rudloff/alltube>
 * Documentation YunoHost pour cette app : <https://yunohost.org/app_alltube>


### PR DESCRIPTION
Rudloff had deleted the demo instance : https://github.com/Rudloff/alltube/issues/422

I have deleted all mention about this link and you can delete on the setting's repository.